### PR TITLE
cds7.3: quoted whitespace is preserved during csv deployment

### DIFF
--- a/test/__snapshots__/main-test.js.snap
+++ b/test/__snapshots__/main-test.js.snap
@@ -9,7 +9,7 @@ exports[`main Entity with key including reserved/escaped uri characters 1`] = `
         "uri": "/odata/v2/main/Favorite('WE%20DE-SFSNRF')",
       },
       "name": "WE DE-SFSNRF",
-      "value": "",
+      "value": " ",
     },
     {
       "__metadata": {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -2795,7 +2795,6 @@ describe("main", () => {
       name = name.replace(/''/g, "'");
       let value = name.substr(2, 1);
       // Special handling
-      value = value === " " ? "" : value;
       value = value === "\\" ? "\\\\" : value;
       expect(data).toEqual({
         __metadata: {


### PR DESCRIPTION
It seems to me that the tests accepted the previously (in my opinion) wrong behavior.
With cds 7.3 the quoted whitespace is preserved.