### PR TITLE
fix: use cds.root as location for package.json

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -8,7 +8,7 @@ const cov2ap = require("./src");
 const PLUGIN = "@cap-js-community/odata-v2-adapter";
 const PLUGIN_CONFIG = [PLUGIN, `${PLUGIN}/cds-plugin`, `${PLUGIN}/cds-plugin.js`];
 
-const packageJSON = require(path.join(process.cwd(), "package.json"));
+const packageJSON = require(path.join(cds.root, "package.json"));
 const pluginActive =
   (cds.env.cov2ap && cds.env.cov2ap.plugin) ||
   (packageJSON &&


### PR DESCRIPTION
`process.cwd()` is dependent on the location of the process, while `cds.root` always points to the project root.
Most often and by default `cds.root` points to `process.cwd()` but in the context of `cds.test` the depending on the directory of the process, the wrong package.json might be read.