### PR TITLE
fix: Store `__elements__` as non-enumerable property on definitions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4254,7 +4254,7 @@ function cov2ap(options = {}) {
       for (const key in definition.elements || {}) {
         keys.push(key);
       }
-      definition.__elements__ = keys.reduce((elements, key) => {
+      const apiElements = keys.reduce((elements, key) => {
         const element = definition.elements[key];
         if (element["@cds.api.ignore"]) {
           return elements;
@@ -4281,6 +4281,7 @@ function cov2ap(options = {}) {
         }
         return elements;
       }, {});
+      Object.defineProperty(definition, "__elements__", { value: apiElements, writable: true, configurable: true });
       return definition.__elements__;
     }
     return {};


### PR DESCRIPTION
The `__elements__` property was set as a normal, enumerable property on CSN definitions.  If that CSN is put in some compiler backends, the compiler may handle it as a normal CSN property, which could fail further down.  This is only an issue if the CSN is put directly into a backend (e.g. the EDMX renderer) and not compiled beforehand.

The compiler may change its behavior to ignore unknown properties (or those that don't match "our" properties such as `__abc__`) in backends in the future, but that needs to be discussed first (and then be implemented).

--------

Tests don't work locally, so I'm relying on the CI system.

---------

In general, it's best to store custom properties as non-enumerable ones. And if the property name does not match `/^(?:[_$=#@][a-zA-Z]*[0-9]*|[a-zA-Z]+[0-9]*)$/;`, the _compilation_ will ignore it. However, the compiler backends don't handle them, yet.