### PR TITLE
Handle multi-protocol services

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -309,7 +309,7 @@ function cov2ap(options = {}) {
     if (!isOData) {
       return;
     }
-    const provider = (entity) => {
+    const provider = (entity, endpoint) => {
       // endpoint is passed since sap/cds 7.7
       if (endpoint && !endpoint.kind.startsWith("odata")) {
         return;

--- a/src/index.js
+++ b/src/index.js
@@ -310,6 +310,10 @@ function cov2ap(options = {}) {
       return;
     }
     const provider = (entity) => {
+      // endpoint is passed since sap/cds 7.7
+      if (endpoint && !endpoint.kind.startsWith("odata")) {
+        return;
+      }
       const path = serviceODataV4Path(service);
       const href = `${sourcePath}${sourceServicePath(path)}/${entity || "$metadata"}`;
       return { href, name: `${entity || "$metadata"} (V2)`, title: "OData V2" };


### PR DESCRIPTION
Don't show the links for non-OData endpoints, e.g. for the rest endpoint if `@protocol: ['rest', 'odata']` is configured.

From sap/cds 7.7, the endpoint is passed in to the link provider, so react on it.  Still be compatible with older cds versions.