### PR TITLE
chore: Suppress deprecation warning caused by http-proxy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,13 @@ const express = require("express");
 const expressFileUpload = require("express-fileupload");
 const cds = require("@sap/cds");
 const { promisify } = require("util");
+
+// Suppress deprecation warning in Node 22 due to http-proxy using util._extend()
+// -> see: https://github.com/http-party/node-http-proxy/pull/1668
+// -> see: https://github.com/http-party/node-http-proxy/pull/1666
+require('util')._extend = Object.assign
 const { createProxyMiddleware } = require("http-proxy-middleware");
+
 const bodyParser = require("body-parser");
 require("body-parser-xml")(bodyParser);
 const xml2js = require("xml2js");


### PR DESCRIPTION
Suppress deprecation warning in Node 22 due to http-proxy using util._extend() → see:

- https://github.com/http-party/node-http-proxy/pull/1666
- https://github.com/http-party/node-http-proxy/pull/1668

As `http-proxy` seems to be not well maintained, this hack would suppress those annoying warnings.