### PR TITLE
Adjust test expects for `odata_new_adapter`

### DIFF
--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -22,7 +22,7 @@ describe("batch", () => {
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({});
     expect(response.headers).toMatchObject({
-      "content-type": "application/json",
+      "content-type": expect.stringMatching(/application\/json/),
       dataserviceversion: "2.0",
     });
     response = await util.callMultipartHead(request, "/odata/v2/main/$batch", undefined, {
@@ -173,7 +173,7 @@ describe("batch", () => {
     response = await util.callRead(request, `/odata/v2/main/Header(guid'${id}')`);
     expect(response.statusCode).toEqual(200);
     expect(response.body.d.name).toEqual("Test: èèòàù");
-    expect(response.headers["content-type"]).toEqual("application/json");
+    expect(response.headers["content-type"]).toMatch(/application\/json/);
   });
 
   it("POST request changeset with misplaced content-id", async () => {

--- a/test/draft.test.js
+++ b/test/draft.test.js
@@ -22,11 +22,9 @@ describe("draft", () => {
       accept: "application/json",
     });
     expect(response.body).toBeDefined();
-    expect(response.body).toEqual({
-      d: {
-        EntitySets: ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"],
-      },
-    });
+    expect(response.body.d.EntitySets.sort()).toEqual(
+      ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"].sort(),
+    );
   });
 
   it("GET $metadata", async () => {

--- a/test/dummy.test.js
+++ b/test/dummy.test.js
@@ -20,11 +20,9 @@ describe("dummy", () => {
       accept: "application/json",
     });
     expect(response.body).toBeDefined();
-    expect(response.body).toEqual({
-      d: {
-        EntitySets: ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"],
-      },
-    });
+    expect(response.body.d.EntitySets.sort()).toEqual(
+      ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"].sort(),
+    );
   });
 
   it("GET service data", async () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -33,7 +33,7 @@ describe("main", () => {
     expect(response.status).toEqual(200);
     expect(response.text).not.toBeDefined();
     expect(response.headers).toMatchObject({
-      "content-type": "application/json",
+      "content-type": expect.stringMatching(/application\/json/),
       dataserviceversion: "2.0",
     });
     response = await util.callHead(request, "/odata/v2/main/Header");
@@ -1554,7 +1554,7 @@ describe("main", () => {
     response = await util.callRead(request, `/odata/v2/main/Header(guid'${id}')`);
     expect(response.statusCode).toEqual(200);
     expect(response.body.d.name).toEqual("Test: èèòàù");
-    expect(response.headers["content-type"]).toEqual("application/json");
+    expect(response.headers["content-type"]).toMatch(/application\/json/);
 
     response = await util.callWrite(
       request,
@@ -1576,7 +1576,7 @@ describe("main", () => {
     response = await util.callRead(request, `/odata/v2/main/Header(guid'${id}')`);
     expect(response.statusCode).toEqual(200);
     expect(response.body.d.name).toEqual("Test: èèòàù");
-    expect(response.headers["content-type"]).toEqual("application/json");
+    expect(response.headers["content-type"]).toMatch(/application\/json/);
   });
 
   it("POST request with x-http-method", async () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1522,7 +1522,7 @@ describe("main", () => {
         code: "405",
         message: {
           lang: "en",
-          value: "Method PATCH not allowed for ENTITY.COLLECTION",
+          value: expect.stringMatching(/PATCH .*not allowed .*entity collection/i),
         },
         severity: "error",
         innererror: {
@@ -1531,7 +1531,7 @@ describe("main", () => {
               code: "405",
               message: {
                 lang: "en",
-                value: "Method PATCH not allowed for ENTITY.COLLECTION",
+          value: expect.stringMatching(/PATCH .*not allowed .*entity collection/i),
               },
               severity: "error",
             },

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1531,7 +1531,7 @@ describe("main", () => {
               code: "405",
               message: {
                 lang: "en",
-          value: expect.stringMatching(/PATCH .*not allowed .*entity collection/i),
+                value: expect.stringMatching(/PATCH .*not allowed .*entity collection/i),
               },
               severity: "error",
             },

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1522,7 +1522,7 @@ describe("main", () => {
         code: "405",
         message: {
           lang: "en",
-          value: expect.stringMatching(/PATCH .*not allowed .*entity collection/i),
+          value: expect.stringMatching(/PATCH .*not allowed .*entity.collection/i),
         },
         severity: "error",
         innererror: {
@@ -1531,7 +1531,7 @@ describe("main", () => {
               code: "405",
               message: {
                 lang: "en",
-                value: expect.stringMatching(/PATCH .*not allowed .*entity collection/i),
+                value: expect.stringMatching(/PATCH .*not allowed .*entity.collection/i),
               },
               severity: "error",
             },

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -20,11 +20,9 @@ describe("path", () => {
       accept: "application/json",
     });
     expect(response.body).toBeDefined();
-    expect(response.body).toEqual({
-      d: {
-        EntitySets: ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"],
-      },
-    });
+    expect(response.body.d.EntitySets.sort()).toEqual(
+      ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"].sort(),
+    );
   });
 
   it("GET service data", async () => {

--- a/test/protocols.test.js
+++ b/test/protocols.test.js
@@ -21,11 +21,9 @@ const expectGETService = async (request, path) => {
     accept: "application/json",
   });
   expect(response.body).toBeDefined();
-  expect(response.body).toEqual({
-    d: {
-      EntitySets: ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"],
-    },
-  });
+  expect(response.body.d.EntitySets.sort()).toEqual(
+    ["Header", "HeaderItem", "HeaderLine", "Header_texts", "HeaderItem_texts"].sort(),
+  );
 };
 
 const expectGETServiceMetadata = async (request, path) => {


### PR DESCRIPTION
Relaxes some of the expects to account for slightly different responses from `odata_new_adapter`, such as more specific header values or different response orders.