### PR TITLE
Fix action not return

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2851,7 +2851,7 @@ function cov2ap(options = {}) {
                 convertHeaders(body, headers, serviceDefinition, req);
                 if (body && isApplicationJSON(contentType)) {
                   if (statusCode === 204) {
-                    body = JSON.stringify({});
+                    body = "";
                   } else {
                     body = convertResponseBody(Object.assign({}, body), headers, req);
                   }
@@ -4779,7 +4779,7 @@ function cov2ap(options = {}) {
               });
               statusCode = (result && result.statusCode) || statusCode;
               statusCodeText = (result && result.statusCodeText) || statusCodeText;
-              body = (result && result.body) || body;
+              body = (result && result.body) ?? body;
               headers = (result && result.headers) || headers;
               if (["HEAD", "OPTIONS", "GET", "DELETE"].includes(method)) {
                 body = "";

--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -439,7 +439,7 @@ describe("batch", () => {
     expect(responses.length).toEqual(1);
     expect(responses.filter((response) => response.statusCode === 204).length).toEqual(1);
     const [first] = responses;
-    expect(first.body).toEqual({});
+    expect(first.body).toEqual("");
     expect(first.contentTransferEncoding).toEqual("binary");
   });
 });


### PR DESCRIPTION
### empty body in batch

![image](https://github.com/user-attachments/assets/2f4be75c-3208-4bcf-b425-3caf76f82084)
![image](https://github.com/user-attachments/assets/3c12fe11-31bb-4e97-bda2-e44008bd2f01)


### current behavior old cds odata adapter
![image](https://github.com/user-attachments/assets/b01aaffb-92a0-44db-8a43-a1b00988e419)

--> 204 | no content --> should have empty body