### PR TITLE
Fix HANA tests: don't overwrite cds.env.requires.db

### DIFF
--- a/test-hana/_env/srv/server.js
+++ b/test-hana/_env/srv/server.js
@@ -9,9 +9,6 @@ try {
   // ignore
 }
 
-cds.env.requires.db = {
-  kind: "hana",
-  credentials,
-};
+cds.env.requires.db.credentials = credentials;
 
 module.exports = cds.server;


### PR DESCRIPTION
HANA tests are failing with cds main, because `cds.env.requires.db.impl` is missing