### PR TITLE
fix: no more double backslash characters in CSVs

### DIFF
--- a/test/__snapshots__/main.test.js.snap
+++ b/test/__snapshots__/main.test.js.snap
@@ -198,10 +198,10 @@ exports[`main Entity with key including reserved/escaped uri characters 1`] = `
     {
       "__metadata": {
         "type": "test.MainService.Favorite",
-        "uri": "/odata/v2/main/Favorite('WE%5C%5CDE-SFSNRF')",
+        "uri": "/odata/v2/main/Favorite('WE%5CDE-SFSNRF')",
       },
-      "name": "WE\\\\DE-SFSNRF",
-      "value": "\\\\",
+      "name": "WE\\DE-SFSNRF",
+      "value": "\\",
     },
     {
       "__metadata": {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -3062,8 +3062,6 @@ describe("main", () => {
       let name = decodeURIComponent(id);
       name = name.replace(/''/g, "'");
       let value = name.substr(2, 1);
-      // Special handling
-      value = value === "\\" ? "\\\\" : value;
       expect(data).toEqual({
         __metadata: {
           type: "test.MainService.Favorite",


### PR DESCRIPTION
fixed in cds main