### PR TITLE
Fix test for direct access of DraftAdministrativeData

### DIFF
--- a/test/draft.test.js
+++ b/test/draft.test.js
@@ -1041,7 +1041,7 @@ describe("draft", () => {
               code: "500",
               message: {
                 lang: "en",
-                value: "Cannot set properties of undefined (setting '_target')",
+                value: "Invalid draft request",
               },
               severity: "error",
               target: "/#TRANSIENT#",
@@ -1050,7 +1050,7 @@ describe("draft", () => {
         },
         message: {
           lang: "en",
-          value: "Cannot set properties of undefined (setting '_target')",
+          value: "Invalid draft request",
         },
         severity: "error",
         target: "/#TRANSIENT#",


### PR DESCRIPTION
In the upcoming version, cds will properly handle invalid direct access of DraftAdministrativeData. Please adapt this test accordingly.

fyi @oklemenz2, @johannes-vogel 