### PR TITLE
Fix literal extraction

### DIFF
--- a/src/lib/extraction-patterns.js
+++ b/src/lib/extraction-patterns.js
@@ -1,0 +1,7 @@
+"use strict"
+
+module.exports = {
+  dateTime: /datetime(?:offset)?(?:'|%27)(.+?)(?:'|%27)/gi,
+  time: /time(?:'|%27)(.+?)(?:'|%27)/gi,
+  date: /datetime(?:'|%27)(.+?)(?:'|%27)/gi,
+}

--- a/test/data-extraction.test.js
+++ b/test/data-extraction.test.js
@@ -1,0 +1,27 @@
+describe("data extraction", () => {
+  const extractionPatterns = require("../src/lib/extraction-patterns");
+
+  it("should extract simple datetime", () => {
+    // Arrange
+    const sut = extractionPatterns.dateTime;
+    const sampleDate = "datetime'20240501'";
+    
+    // Act
+    const result = sampleDate.replace(sut, "$1");
+
+    // Assert
+    expect(result).toBe("20240501");
+  });
+
+  it("should extract encoded datetime", () => {
+    // Arrange
+    const sut = extractionPatterns.dateTime;
+    const sampleDate = "datetime%2720240501%27";
+    
+    // Act
+    const result = sampleDate.replace(sut, "$1");
+
+    // Assert
+    expect(result).toBe("20240501");
+  });
+});


### PR DESCRIPTION
When datetimeoffset is used in filter, regex didn't work because filter is not decoded. To not break behaviour of encoded content of filter (as I see from current tests it should stay encoded), I updated regex to target case where datetime'' was encoded into datetime%27%27