### PR TITLE
test: allow different order of responses in changeset

### DIFF
--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -281,7 +281,13 @@ describe("batch", () => {
     expect(response.statusCode).toEqual(202);
     const responses = util.splitMultipartResponse(response.body);
     expect(responses.length).toEqual(1);
-    const [[first, second]] = responses;
+    let [[first, second]] = responses;
+    // order of requests in changeset can vary
+    if (first.body.d.ID !== id) {
+      let temp = first
+      first = second
+      second = temp
+    }
     expect(first.statusCode).toEqual(200);
     expect(first.contentId).toEqual("1");
     expect(first.contentTransferEncoding).toEqual("binary");
@@ -317,7 +323,13 @@ describe("batch", () => {
     expect(response.statusCode).toEqual(202);
     const responses = util.splitMultipartResponse(response.body);
     expect(responses.length).toEqual(1);
-    const [[first, second]] = responses;
+    let [[first, second]] = responses;
+    // order of requests in changeset can vary
+    if (first.body.d.ID !== id) {
+      let temp = first
+      first = second
+      second = temp
+    }
     expect(first.statusCode).toEqual(200);
     expect(first.contentId).toEqual("1");
     expect(first.contentTransferEncoding).toEqual("binary");


### PR DESCRIPTION
we have done an internal change which results in omitting an async after handler for the second request.

The first request does have an [async after handler](https://github.com/cap-js-community/odata-v2-adapter/blob/ba74ef258854b4a9f180dc5d24b4289e61badc32/test/_env/srv/handlers/main.js#L8) registered in the test which now leads to the situation that the second request finished before the first is finished.