### PR TITLE
Remove old db kind better-sqlite

### DIFF
--- a/test/_env/package.json
+++ b/test/_env/package.json
@@ -26,14 +26,14 @@
     },
     "requires": {
       "db": {
-        "kind": "better-sqlite",
+        "kind": "sqlite",
         "credentials": {
-          "database": ":memory:"
+          "url": ":memory:"
         },
         "[testdb]": {
-          "kind": "better-sqlite",
+          "kind": "sqlite",
           "credentials": {
-            "database": "test.sqlite"
+            "url": "test.sqlite"
           }
         }
       }


### PR DESCRIPTION
Old db kind `better-sqlite` will be removed with cds 9, please adapt.

fyi @oklemenz2 @johannes-vogel 