### PR TITLE
test: Update handlers/draft.js

### DIFF
--- a/test/_env/srv/handlers/draft.js
+++ b/test/_env/srv/handlers/draft.js
@@ -18,7 +18,7 @@ module.exports = (srv) => {
     req.info(info2);
   });
 
-  srv.after("SAVE", Header.drafts, (data, req) => {
+  srv.after(["CREATE", "UPDATE"], Header.drafts, (data, req) => {
     const info = new Error("Success");
     info.code = "INFO";
     info.target = "name";


### PR DESCRIPTION
With the upcoming release of @sap/cds, SAVE on drafts is triggered when drafts are activated. This will cause some test failures in odata-v2-adapter. Could be fixed with this change - please check.

Please also note that, with the next cds version, you will have to update several snapshots because the order of edmx elements changed.

fyi @oklemenz2 / @David-Kunz / @sjvans