### PR TITLE
test for bound action parsing parameters issue

### DIFF
--- a/test/_env/srv/handlers/main.js
+++ b/test/_env/srv/handlers/main.js
@@ -21,6 +21,10 @@ module.exports = (srv) => {
     };
   });
 
+  srv.on("boundEchoAction", Header, async (req) => {
+    return req.data;
+  })
+
   srv.on("boundMassAction", Header, async (req) => {
     return req.data.ids.map((id, index) => {
       return {

--- a/test/_env/srv/main.cds
+++ b/test/_env/srv/main.cds
@@ -223,6 +223,7 @@ service MainService {
     entity Currency as projection on common.Currencies;
 
     entity Header as projection on test.Header actions {
+        action boundEchoAction(name: String, code: String, age: Integer) returns Result;
         action boundAction(num: Integer, text: String) returns Result;
         action boundMassAction(ids: array of String) returns array of Result;
         action boundActionInline(num: Integer, text: String) returns {

--- a/test/_env/util/batch/Batch-BoundEchoAction.txt
+++ b/test/_env/util/batch/Batch-BoundEchoAction.txt
@@ -1,0 +1,8 @@
+--boundary
+Content-Type: application/http
+
+POST Header_boundEchoAction?ID=e0582b6a-6d93-46d9-bd28-98723a285d40&name=null&code=abc2&age=2 HTTP/1.1
+Content-Type: application/json
+
+
+--boundary--

--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -391,6 +391,18 @@ describe("batch", () => {
     expect(second.contentTransferEncoding).toEqual("binary");
   });
 
+  it("POST bound action request", async () => {
+    let payload = fs.readFileSync(__dirname + "/_env/util/batch/Batch-BoundEchoAction.txt", "utf8");
+    payload = payload.replace(/\r\n/g, "\n");
+    let response = await util.callMultipart(request, "/odata/v2/main/$batch", payload);
+    expect(response.statusCode).toEqual(202);
+    const responses = util.splitMultipartResponse(response.body);
+    expect(responses.length).toEqual(1);
+    expect(responses.filter((response) => response.statusCode === 200).length).toEqual(1);
+    const [first] = responses;
+    expect(first.body.d.Header_boundEchoAction.name).toEqual(null)
+  });
+
   it("GET with x-forwarded headers", async () => {
     let response = await util.callWrite(request, "/odata/v2/main/Header", {
       name: "Test %22",


### PR DESCRIPTION
Hello, I added the test for the bound action, which fails when parsing a null value. This occurs because when the bound action is called in batch request, the input parameter **&name=null** is expected to be parsed as **null**, but in the custom handler, this parameter is coming as the string **'null'**

<img width="532" height="230" alt="image" src="https://github.com/user-attachments/assets/dd919070-63e7-4d1a-b044-b304849bb21b" />

Could you suggest how to fix it?