### PR TITLE
test: prep for cds10 - srv.entities does not include texts entities anymore

### DIFF
--- a/test/_env/srv/handlers/draft.js
+++ b/test/_env/srv/handlers/draft.js
@@ -1,7 +1,8 @@
 "use strict";
 
 module.exports = (srv) => {
-  const { Header, HeaderItem, ["HeaderItem.texts"]: HeaderItemText } = srv.entities;
+  const { Header, HeaderItem } = srv.entities;
+  const HeaderItemText = HeaderItems.texts;
 
   srv.after("draftPrepare", Header.drafts, (data, req) => {
     const info1 = new Error("This is a Warning");

--- a/test/_env/srv/handlers/draft.js
+++ b/test/_env/srv/handlers/draft.js
@@ -2,7 +2,7 @@
 
 module.exports = (srv) => {
   const { Header, HeaderItem } = srv.entities;
-  const HeaderItemText = HeaderItems.texts;
+  const HeaderItemText = HeaderItem.texts;
 
   srv.after("draftPrepare", Header.drafts, (data, req) => {
     const info1 = new Error("This is a Warning");


### PR DESCRIPTION

The default behavior of `cds.features.compat_texts_entities` changes in cds10. `srv.entities` does not include the `.texts` entities anymore. They can be reached through `<entity>.texts` (as in this PR) or through `<model>.definitions`.

→ I suggest to adapt the test handler to use the correct api.